### PR TITLE
Add $options param to trackCancellation method

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -102,20 +102,21 @@ class Tracking extends FirstPromoter
      *
      * @param      $email
      * @param null $uid
+     * @param array $options
      *
      * @return object
      * @throws \Exception
      */
-    public static function trackCancellation($email, $uid = null)
+    public static function trackCancellation($email, $uid = null, array $options = [])
     {
         if (empty($email)) {
             throw new Exception('Email is required.');
         }
 
-        $options = [
+        $options = array_merge([
             'email'     => $email,
             'uid'       => $uid
-        ];
+        ], $options);
 
         return self::request('POST', 'track/cancellation', $options);
     }


### PR DESCRIPTION
Allow extra `$options` to be passed through to `trackCancellation` method in order to be able to pass in `wid` required param.